### PR TITLE
Add option to disable notifications

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,16 +6,19 @@
 let title = browser.i18n.getMessage('title');
 let maxTabs = 10;
 let includePinned = false;
+let showNotifications = true;
 let colorScale = chroma.scale(['#A6A6A6', '#B90000']);
 
 function updatePrefs() {
   return new Promise((resolve, reject) => {
     browser.storage.sync.get({
       "maxTabs": 10,
-      "includePinned": false
+      "includePinned": false,
+      "showNotifications": true,
     }, items => {
       maxTabs = items.maxTabs;
       includePinned = items.includePinned;
+      showNotifications = items.showNotifications;
       resolve();
     });
   });
@@ -50,11 +53,13 @@ browser.tabs.onCreated.addListener(tab => {
     queryNumTabs().then(numTabs => {
       if (numTabs > maxTabs) {
         browser.tabs.remove(tab.id).then(() => {
-          browser.notifications.create("", {
-            type: "basic",
-            title: title,
-            message: browser.i18n.getMessage('notOpenMaxTabs', maxTabs)
-          });
+          if(showNotifications) {
+            browser.notifications.create("", {
+              type: "basic",
+              title: title,
+              message: browser.i18n.getMessage('notOpenMaxTabs', maxTabs)
+            });
+          }
         });
       } else {
         updateButton(numTabs);

--- a/options/options.html
+++ b/options/options.html
@@ -29,6 +29,11 @@
         <input type="checkbox" id="include-pinned">
     </div>
     <hr>
+    <div class="prefs">
+        <label for="show-notifications">Show notifications:</label>
+        <input type="checkbox" id="show-notifications" checked>
+      </div>
+    <hr>
     <button id="submitbtn" type="submit">Save</button>
   </form>
   <script src="options.js"></script>

--- a/options/options.js
+++ b/options/options.js
@@ -2,9 +2,11 @@
 function saveOptions(e) {
   let maxTabs = document.getElementById("max-tabs").value;
   let includePinned = document.getElementById("include-pinned").checked;
+  let showNotifications = document.getElementById("show-notifications").checked;
   browser.storage.sync.set({
     maxTabs: maxTabs,
-    includePinned: includePinned
+    includePinned: includePinned,
+    showNotifications: showNotifications,
   });
   e.preventDefault();
 }
@@ -12,11 +14,13 @@ function saveOptions(e) {
 function restoreOptions() {
   var gettingItem = browser.storage.sync.get({
     maxTabs: 10,
-    includePinned: false
+    includePinned: false,
+    showNotifications: true,
   });
   gettingItem.then((res) => {
     document.getElementById("max-tabs").value = res.maxTabs;
     document.getElementById("include-pinned").checked = res.includePinned;
+    document.getElementById("show-notifications").checked = res.showNotifications;
   });
 }
 


### PR DESCRIPTION
This PR adds a checkbox in the settings page to allow the users to decide if they want to receive a notification after reach the limit of maximum tabs opened or not.

Notifications are still enabled by default.